### PR TITLE
feat(svg,text): anchors and rotated edge labels

### DIFF
--- a/src/main/java/net/sourceforge/plantuml/emoji/SvgNanoParser.java
+++ b/src/main/java/net/sourceforge/plantuml/emoji/SvgNanoParser.java
@@ -41,7 +41,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -58,6 +60,7 @@ import net.sourceforge.plantuml.klimt.font.FontConfiguration;
 import net.sourceforge.plantuml.klimt.font.StringBounder;
 import net.sourceforge.plantuml.klimt.font.UFont;
 import net.sourceforge.plantuml.klimt.geom.XDimension2D;
+import net.sourceforge.plantuml.klimt.geom.XPoint2D;
 import net.sourceforge.plantuml.klimt.shape.AbstractTextBlock;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.klimt.shape.UEllipse;
@@ -71,8 +74,8 @@ import net.sourceforge.plantuml.openiconic.SvgPath;
 
 public class SvgNanoParser implements Sprite, GrayLevelRange {
 
-	private static final Pattern P_TEXT_OR_DRAW = Pattern
-			.compile("(\\<text .*?\\</text\\>)|(\\<(svg|path|g|circle|ellipse)[^<>]*\\>)|(\\</[^<>]*\\>)");
+        private static final Pattern P_TEXT_OR_DRAW = Pattern
+                        .compile("(\\<text .*?\\</text\\>)|(\\<(svg|path|g|circle|ellipse|rect|line)[^<>]*\\>)|(\\</[^<>]*\\>)");
 
 	private static final Pattern P_TEXT = Pattern.compile("\\<text[^<>]*\\>(.*?)\\</text\\>");
 	private static final Pattern P_FONT_SIZE = Pattern.compile("^(\\d+)p[tx]$");
@@ -101,18 +104,26 @@ public class SvgNanoParser implements Sprite, GrayLevelRange {
 	private static final Pattern DATA_STROKE_WIDTH = Pattern.compile("stroke-width" + equals_something);
 	private static final Pattern DATA_STYLE = Pattern.compile("style" + equals_something);
 	private static final Pattern DATA_TRANSFORM = Pattern.compile("transform" + equals_something);
-	private static final Pattern DATA_X = Pattern.compile("x" + equals_something);
-	private static final Pattern DATA_Y = Pattern.compile("y" + equals_something);
+        private static final Pattern DATA_X = Pattern.compile("x" + equals_something);
+        private static final Pattern DATA_Y = Pattern.compile("y" + equals_something);
+        private static final Pattern DATA_X1 = Pattern.compile("x1" + equals_something);
+        private static final Pattern DATA_Y1 = Pattern.compile("y1" + equals_something);
+        private static final Pattern DATA_X2 = Pattern.compile("x2" + equals_something);
+        private static final Pattern DATA_Y2 = Pattern.compile("y2" + equals_something);
+        private static final Pattern DATA_WIDTH = Pattern.compile("width" + equals_something);
+        private static final Pattern DATA_HEIGHT = Pattern.compile("height" + equals_something);
+        private static final Pattern DATA_ID = Pattern.compile("(?i)id" + equals_something);
 
 	private static final String colon_something = ":([^;\"]+)";
 	private static final Pattern STYLE_FILL = Pattern.compile(Pattern.quote("fill") + colon_something);
 	private static final Pattern STYLE_FONT_SIZE = Pattern.compile(Pattern.quote("font-size") + colon_something);
 	private static final Pattern STYLE_FONT_FAMILY = Pattern.compile(Pattern.quote("font-family") + colon_something);
 
-	private final List<String> data = new ArrayList<>();
-	private int minGray = 999;
-	private int maxGray = -1;
-	private List<String> svg;
+        private final List<String> data = new ArrayList<>();
+        private int minGray = 999;
+        private int maxGray = -1;
+        private List<String> svg;
+        private final Map<String, XPoint2D> anchors = new HashMap<>();
 
 	private String extract(Pattern p, String s) {
 		final Matcher m = p.matcher(s);
@@ -152,13 +163,17 @@ public class SvgNanoParser implements Sprite, GrayLevelRange {
 				ugs = applyTransform(ugs, s);
 			} else if (s.startsWith("<circle ")) {
 				drawCircle(ugs, s, stackG);
-			} else if (s.startsWith("<ellipse ")) {
-				drawEllipse(ugs, s, stackG);
-			} else if (s.startsWith("<text ")) {
-				drawText(ugs, s, stackG);
-			} else {
-				System.err.println("**?=" + s);
-			}
+                        } else if (s.startsWith("<ellipse ")) {
+                                drawEllipse(ugs, s, stackG);
+                        } else if (s.startsWith("<rect ")) {
+                                drawRect(ugs, s, stackG);
+                        } else if (s.startsWith("<line ")) {
+                                drawLine(ugs, s, stackG);
+                        } else if (s.startsWith("<text ")) {
+                                drawText(ugs, s, stackG);
+                        } else {
+                                System.err.println("**?=" + s);
+                        }
 		}
 	}
 
@@ -167,23 +182,25 @@ public class SvgNanoParser implements Sprite, GrayLevelRange {
 			for (String singleLine : svg) {
 				final Matcher m = P_TEXT_OR_DRAW.matcher(singleLine);
 				while (m.find()) {
-					final String s = m.group(0);
-					if (s.startsWith("<path") || s.startsWith("<g ") || s.startsWith("<g>") || s.startsWith("</g>")
-							|| s.startsWith("<circle ") || s.startsWith("<ellipse ") || s.startsWith("<text "))
-						data.add(s);
-					else if (s.startsWith("<svg") || s.startsWith("</svg")) {
-						// Ignore
-					} else
-						System.err.println("???=" + s);
+                                        final String s = m.group(0);
+                                        if (s.startsWith("<path") || s.startsWith("<g ") || s.startsWith("<g>")
+                                                        || s.startsWith("</g>") || s.startsWith("<circle ")
+                                                        || s.startsWith("<ellipse ") || s.startsWith("<text ")
+                                                        || s.startsWith("<rect ") || s.startsWith("<line "))
+                                                data.add(s);
+                                        else if (s.startsWith("<svg") || s.startsWith("</svg")) {
+                                                // Ignore
+                                        } else
+                                                System.err.println("???=" + s);
 				}
 			}
 		}
 		return Collections.unmodifiableCollection(data);
 	}
 
-	private UGraphicWithScale applyFillAndStroke(UGraphicWithScale ugs, String s, Deque<String> stackG) {
-		final String fillString = getFillString(s, stackG);
-		final String strokeString = extract(DATA_STROKE, s);
+        private UGraphicWithScale applyFillAndStroke(UGraphicWithScale ugs, String s, Deque<String> stackG) {
+                final String fillString = getFillString(s, stackG);
+                final String strokeString = extract(DATA_STROKE, s);
 
 		final String strokeWidth = extract(DATA_STROKE_WIDTH, s);
 		if (strokeWidth != null) {
@@ -208,8 +225,16 @@ public class SvgNanoParser implements Sprite, GrayLevelRange {
 			ugs = ugs.apply(fill.bg());
 		}
 
-		return ugs;
-	}
+                return ugs;
+        }
+
+        private void registerPoint(String s, double x, double y, UGraphicWithScale ugs) {
+                final String id = extract(DATA_ID, s);
+                if (id != null) {
+                        XPoint2D p = new XPoint2D(x, y).transform(ugs.getAffineTransform());
+                        anchors.put(id, p);
+                }
+        }
 
 	private void drawCircle(UGraphicWithScale ugs, String s, Deque<String> stackG) {
 		ugs = applyFillAndStroke(ugs, s, stackG);
@@ -224,16 +249,17 @@ public class SvgNanoParser implements Sprite, GrayLevelRange {
 		final double cx = Double.parseDouble(extract(DATA_CX, s)) * scalex;
 		final double cy = Double.parseDouble(extract(DATA_CY, s)) * scaley;
 		final double rx = Double.parseDouble(extract(DATA_R, s)) * scalex;
-		final double ry = Double.parseDouble(extract(DATA_R, s)) * scaley;
+                final double ry = Double.parseDouble(extract(DATA_R, s)) * scaley;
 
-		final UTranslate translate = new UTranslate(deltax + cx - rx, deltay + cy - ry);
-		ugs.apply(translate).draw(UEllipse.build(rx * 2, ry * 2));
-	}
+                final UTranslate translate = new UTranslate(deltax + cx - rx, deltay + cy - ry);
+                ugs.apply(translate).draw(UEllipse.build(rx * 2, ry * 2));
+                registerPoint(s, deltax + cx, deltay + cy, ugs);
+        }
 
-	private void drawEllipse(UGraphicWithScale ugs, String s, Deque<String> stackG) {
-		final boolean debug = false;
-		ugs = applyFillAndStroke(ugs, s, stackG);
-		ugs = applyTransform(ugs, s);
+        private void drawEllipse(UGraphicWithScale ugs, String s, Deque<String> stackG) {
+                final boolean debug = false;
+                ugs = applyFillAndStroke(ugs, s, stackG);
+                ugs = applyTransform(ugs, s);
 
 		final double cx = Double.parseDouble(extract(DATA_CX, s));
 		final double cy = Double.parseDouble(extract(DATA_CY, s));
@@ -265,12 +291,53 @@ public class SvgNanoParser implements Sprite, GrayLevelRange {
 
 		path.closePath();
 
-		path = path.translate(cx - rx, cy - ry);
-		path = path.affine(ugs.getAffineTransform(), ugs.getAngle(), ugs.getScale());
+                path = path.translate(cx - rx, cy - ry);
+                path = path.affine(ugs.getAffineTransform(), ugs.getAngle(), ugs.getScale());
 
-		ugs.draw(path);
+                ugs.draw(path);
 
-	}
+                registerPoint(s, cx, cy, ugs);
+        }
+
+        private void drawRect(UGraphicWithScale ugs, String s, Deque<String> stackG) {
+                ugs = applyFillAndStroke(ugs, s, stackG);
+                ugs = applyTransform(ugs, s);
+
+                final double x = Double.parseDouble(extract(DATA_X, s));
+                final double y = Double.parseDouble(extract(DATA_Y, s));
+                final double w = Double.parseDouble(extract(DATA_WIDTH, s));
+                final double h = Double.parseDouble(extract(DATA_HEIGHT, s));
+
+                UPath path = UPath.none();
+                path.moveTo(x, y);
+                path.lineTo(x + w, y);
+                path.lineTo(x + w, y + h);
+                path.lineTo(x, y + h);
+                path.closePath();
+
+                path = path.affine(ugs.getAffineTransform(), ugs.getAngle(), ugs.getScale());
+                ugs.draw(path);
+
+                registerPoint(s, x + w / 2, y + h / 2, ugs);
+        }
+
+        private void drawLine(UGraphicWithScale ugs, String s, Deque<String> stackG) {
+                ugs = applyFillAndStroke(ugs, s, stackG);
+                ugs = applyTransform(ugs, s);
+
+                final double x1 = Double.parseDouble(extract(DATA_X1, s));
+                final double y1 = Double.parseDouble(extract(DATA_Y1, s));
+                final double x2 = Double.parseDouble(extract(DATA_X2, s));
+                final double y2 = Double.parseDouble(extract(DATA_Y2, s));
+
+                UPath path = UPath.none();
+                path.moveTo(x1, y1);
+                path.lineTo(x2, y2);
+                path = path.affine(ugs.getAffineTransform(), ugs.getAngle(), ugs.getScale());
+                ugs.draw(path);
+
+                registerPoint(s, (x1 + x2) / 2, (y1 + y2) / 2, ugs);
+        }
 
 	private void drawText(UGraphicWithScale ugs, String s, Deque<String> stackG) {
 		final double x = Double.parseDouble(extract(DATA_X, s));
@@ -443,7 +510,7 @@ public class SvgNanoParser implements Sprite, GrayLevelRange {
 	}
 
 	@Override
-	public TextBlock asTextBlock(final HColor fontColor, final HColor forcedColor, final double scale) {
+        public TextBlock asTextBlock(final HColor fontColor, final HColor forcedColor, final double scale) {
 
 		final UImageSvg data = new UImageSvg(svg.get(0), scale);
 		final double width = data.getWidth();
@@ -458,10 +525,14 @@ public class SvgNanoParser implements Sprite, GrayLevelRange {
 			public XDimension2D calculateDimension(StringBounder stringBounder) {
 				return new XDimension2D(width, height);
 			}
-		};
-	}
+                };
+        }
 
-	private void computeMinMaxGray() {
+        public XPoint2D getPoint(String id) {
+                return anchors.get(id);
+        }
+
+        private void computeMinMaxGray() {
 		for (String s : getData()) {
 			if (s.contains("<path ") || s.contains("<g ") || s.contains("<circle ") || s.contains("<ellipse ")) {
 				final String fillString = getFillString(s, null);

--- a/src/main/java/net/sourceforge/plantuml/klimt/drawing/UGraphicRotated.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/drawing/UGraphicRotated.java
@@ -1,0 +1,62 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2025, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ */
+package net.sourceforge.plantuml.klimt.drawing;
+
+import net.sourceforge.plantuml.klimt.UChange;
+import net.sourceforge.plantuml.klimt.UShape;
+import net.sourceforge.plantuml.klimt.shape.UText;
+
+public class UGraphicRotated extends UGraphicDelegator {
+    private final double angle;
+
+    public UGraphicRotated(UGraphic ug, double angle) {
+        super(ug);
+        this.angle = angle;
+    }
+
+    @Override
+    public void draw(UShape shape) {
+        if (shape instanceof UText) {
+            UText text = (UText) shape;
+            super.draw(text.withAngle(angle));
+        } else {
+            super.draw(shape);
+        }
+    }
+
+    @Override
+    public UGraphic apply(UChange change) {
+        return new UGraphicRotated(getUg().apply(change), angle);
+    }
+}

--- a/src/main/java/net/sourceforge/plantuml/klimt/drawing/g2d/DriverTextG2d.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/drawing/g2d/DriverTextG2d.java
@@ -72,36 +72,35 @@ public class DriverTextG2d implements UDriver<UText, Graphics2D> {
 		this.stringBounder = stringBounder;
 	}
 
-	public void draw(UText shape, double x, double y, ColorMapper mapper, UParam param, Graphics2D g2d) {
-		final FontConfiguration fontConfiguration = shape.getFontConfiguration();
+        public void draw(UText shape, double x, double y, ColorMapper mapper, UParam param, Graphics2D g2d) {
+                final FontConfiguration fontConfiguration = shape.getFontConfiguration();
 
-		if (fontConfiguration.getColor().isTransparent())
-			return;
+                if (fontConfiguration.getColor().isTransparent())
+                        return;
 
-		final String text = shape.getText();
+                final String text = shape.getText();
 
-		final List<StyledString> strings = StyledString.build(text);
+                final List<StyledString> strings = StyledString.build(text);
+                final double angle = shape.getAngle();
 
-		for (StyledString styledString : strings) {
-			final FontConfiguration fc = styledString.getStyle() == FontStyle.BOLD ? fontConfiguration.bold()
-					: fontConfiguration;
-			x += printSingleText(g2d, fc, styledString.getText(), x, y, mapper);
-		}
-	}
+                for (StyledString styledString : strings) {
+                        final FontConfiguration fc = styledString.getStyle() == FontStyle.BOLD ? fontConfiguration.bold()
+                                        : fontConfiguration;
+                        x += printSingleText(g2d, fc, styledString.getText(), x, y, mapper, angle);
+                }
+        }
 
-	private double printSingleText(Graphics2D g2d, final FontConfiguration fontConfiguration, final String text,
-			double x, double y, ColorMapper mapper) {
-		final UFont font = fontConfiguration.getFont();
-		final HColor extended = fontConfiguration.getExtendedColor();
+        private double printSingleText(Graphics2D g2d, final FontConfiguration fontConfiguration, final String text,
+                        double x, double y, ColorMapper mapper, double angleDeg) {
+                final UFont font = fontConfiguration.getFont();
+                final HColor extended = fontConfiguration.getExtendedColor();
 
-		final XDimension2D dim = stringBounder.calculateDimension(font, text);
-		final double height = max(10, dim.getHeight());
-		final double width = dim.getWidth();
+                final XDimension2D dim = stringBounder.calculateDimension(font, text);
+                final double height = max(10, dim.getHeight());
+                final double width = dim.getWidth();
 
-		final int orientation = 0;
-
-		g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-		g2d.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+                g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+                g2d.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
 		// https://stackoverflow.com/questions/31536952/how-to-fix-text-quality-in-java-graphics
 		// https://stackoverflow.com/questions/72818320/improve-java2d-drawing-quality-on-hi-resolution-monitors
 		/*
@@ -111,38 +110,41 @@ public class DriverTextG2d implements UDriver<UText, Graphics2D> {
 		 * RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
 		 */
 
-		g2d.setFont(font.getUnderlayingFont(text));
+                g2d.setFont(font.getUnderlayingFont(text));
 
-		if (orientation == 90) {
-			final AffineTransform orig = g2d.getTransform();
-			g2d.translate(x, y);
-			g2d.rotate(Math.PI / 2);
-			g2d.drawString(text, 0, 0);
-			g2d.setTransform(orig);
+                final double theta = Math.toRadians(angleDeg);
 
-		} else if (orientation == 0) {
+                if (Math.abs(theta) > 0.0001) {
+                        final AffineTransform orig = g2d.getTransform();
+                        g2d.translate(x, y);
+                        g2d.rotate(theta);
+                        g2d.setColor(fontConfiguration.getColor().toColor(mapper));
+                        g2d.drawString(text, 0, 0);
+                        g2d.setTransform(orig);
 
-			if (fontConfiguration.containsStyle(FontStyle.BACKCOLOR)) {
-				final Rectangle2D.Double area = new Rectangle2D.Double(x, y - height + 1.5, width, height);
-				if (extended instanceof HColorGradient) {
-					final GradientPaint paint = DriverRectangleG2d.getPaintGradient(x, y, mapper, width, height,
-							extended);
-					g2d.setPaint(paint);
-					g2d.fill(area);
-				} else {
-					final Color backColor = extended.toColor(mapper);
-					if (backColor != null) {
-						g2d.setColor(backColor);
-						g2d.setBackground(backColor);
-						g2d.fill(area);
-					}
-				}
-			}
-			visible.ensureVisible(x, y - height + 1.5);
-			visible.ensureVisible(x + width, y + 1.5);
+                } else {
 
-			g2d.setColor(fontConfiguration.getColor().toColor(mapper));
-			g2d.drawString(text, (float) x, (float) y);
+                        if (fontConfiguration.containsStyle(FontStyle.BACKCOLOR)) {
+                                final Rectangle2D.Double area = new Rectangle2D.Double(x, y - height + 1.5, width, height);
+                                if (extended instanceof HColorGradient) {
+                                        final GradientPaint paint = DriverRectangleG2d.getPaintGradient(x, y, mapper, width, height,
+                                                        extended);
+                                        g2d.setPaint(paint);
+                                        g2d.fill(area);
+                                } else {
+                                        final Color backColor = extended.toColor(mapper);
+                                        if (backColor != null) {
+                                                g2d.setColor(backColor);
+                                                g2d.setBackground(backColor);
+                                                g2d.fill(area);
+                                        }
+                                }
+                        }
+                        visible.ensureVisible(x, y - height + 1.5);
+                        visible.ensureVisible(x + width, y + 1.5);
+
+                        g2d.setColor(fontConfiguration.getColor().toColor(mapper));
+                        g2d.drawString(text, (float) x, (float) y);
 
 			if (fontConfiguration.containsStyle(FontStyle.UNDERLINE)) {
 				if (extended != null)

--- a/src/main/java/net/sourceforge/plantuml/klimt/drawing/svg/DriverTextSvg.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/drawing/svg/DriverTextSvg.java
@@ -50,6 +50,7 @@ import net.sourceforge.plantuml.klimt.font.UFontContext;
 import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 import net.sourceforge.plantuml.klimt.shape.UText;
 import net.sourceforge.plantuml.project.lang.Words;
+import java.util.Map;
 
 public class DriverTextSvg implements UDriver<UText, SvgGraphics> {
 	// ::remove file when __HAXE__
@@ -141,10 +142,14 @@ public class DriverTextSvg implements UDriver<UText, SvgGraphics> {
 
 		}
 
-		final HColor textColor = fontConfiguration.getColor();
-		svg.setFillColor(textColor.toSvg(mapper));
-		svg.text(text, x, y, font.getFamily(text, UFontContext.SVG), font.getSize(), fontWeight, fontStyle, textDecoration,
-				width, fontConfiguration.getAttributes(), backColor);
+                final HColor textColor = fontConfiguration.getColor();
+                svg.setFillColor(textColor.toSvg(mapper));
+                final Map<String, String> attrs = new java.util.HashMap<>(fontConfiguration.getAttributes());
+                if (shape.getAngle() != 0) {
+                        attrs.put("transform", "rotate(" + (-shape.getAngle()) + " " + x + " " + y + ")");
+                }
+                svg.text(text, x, y, font.getFamily(text, UFontContext.SVG), font.getSize(), fontWeight, fontStyle, textDecoration,
+                                width, attrs, backColor);
 
 		if (extraLine != null) {
 			svg.setStrokeColor(extraLine.toSvg(mapper));

--- a/src/main/java/net/sourceforge/plantuml/klimt/shape/TextBlockRotated.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/shape/TextBlockRotated.java
@@ -1,0 +1,59 @@
+/* ========================================================================
+ * PlantUML : a free UML diagram generator
+ * ========================================================================
+ *
+ * (C) Copyright 2009-2025, Arnaud Roques
+ *
+ * Project Info:  https://plantuml.com
+ *
+ * If you like this project or if you find it useful, you can support us at:
+ *
+ * https://plantuml.com/patreon (only 1$ per month!)
+ * https://plantuml.com/paypal
+ *
+ * This file is part of PlantUML.
+ *
+ * PlantUML is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlantUML distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ *
+ * Original Author:  Arnaud Roques
+ */
+package net.sourceforge.plantuml.klimt.shape;
+
+import net.sourceforge.plantuml.klimt.drawing.UGraphic;
+import net.sourceforge.plantuml.klimt.drawing.UGraphicRotated;
+import net.sourceforge.plantuml.klimt.font.StringBounder;
+import net.sourceforge.plantuml.klimt.geom.XDimension2D;
+
+public class TextBlockRotated extends AbstractTextBlock implements TextBlock {
+    private final TextBlock inner;
+    private final double angle;
+
+    public TextBlockRotated(TextBlock inner, double angle) {
+        this.inner = inner;
+        this.angle = angle;
+    }
+
+    @Override
+    public void drawU(UGraphic ug) {
+        inner.drawU(new UGraphicRotated(ug, angle));
+    }
+
+    @Override
+    public XDimension2D calculateDimension(StringBounder stringBounder) {
+        return inner.calculateDimension(stringBounder);
+    }
+}

--- a/src/main/java/net/sourceforge/plantuml/klimt/shape/UText.java
+++ b/src/main/java/net/sourceforge/plantuml/klimt/shape/UText.java
@@ -43,29 +43,33 @@ import net.sourceforge.plantuml.klimt.geom.XDimension2D;
 
 public class UText implements UShape {
 
-	private final String text;
-	private final FontConfiguration font;
-	private final int orientation;
+        private final String text;
+        private final FontConfiguration font;
+        private final double angle;
 
 	@Override
 	public String toString() {
 		return "UText[" + text + "]";
 	}
 
-	private UText(String text, FontConfiguration font, int orientation) {
-		assert text.indexOf('\t') == -1;
-		this.text = text.replace(Jaws.BLOCK_E1_NEWLINE, '\u21b5').replace(Jaws.BLOCK_E1_BREAKLINE, '\u23ce');
-		this.font = font;
-		this.orientation = orientation;
-	}
+        private UText(String text, FontConfiguration font, double angle) {
+                assert text.indexOf('\t') == -1;
+                this.text = text.replace(Jaws.BLOCK_E1_NEWLINE, '\u21b5').replace(Jaws.BLOCK_E1_BREAKLINE, '\u23ce');
+                this.font = font;
+                this.angle = angle;
+        }
 
-	public static UText build(String text, FontConfiguration font) {
-		return new UText(text, font, 0);
-	}
+        public static UText build(String text, FontConfiguration font) {
+                return new UText(text, font, 0);
+        }
 
-	public UText withOrientation(int orientation) {
-		return new UText(text, font, orientation);
-	}
+        public UText withOrientation(int orientation) {
+                return withAngle(orientation);
+        }
+
+        public UText withAngle(double angle) {
+                return new UText(text, font, angle);
+        }
 
 	public String getText() {
 		return text;
@@ -81,9 +85,13 @@ public class UText implements UShape {
 	}
 	// ::done
 
-	public final int getOrientation() {
-		return orientation;
-	}
+        public final int getOrientation() {
+                return (int) angle;
+        }
+
+        public final double getAngle() {
+                return angle;
+        }
 
 	public XDimension2D calculateDimension(StringBounder stringBounder) {
 		return stringBounder.calculateDimension(font.getFont(), text);

--- a/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
+++ b/src/main/java/net/sourceforge/plantuml/svek/SvekEdge.java
@@ -85,6 +85,7 @@ import net.sourceforge.plantuml.klimt.geom.XPoint2D;
 import net.sourceforge.plantuml.klimt.shape.DotPath;
 import net.sourceforge.plantuml.klimt.shape.TextBlock;
 import net.sourceforge.plantuml.klimt.shape.TextBlockUtils;
+import net.sourceforge.plantuml.klimt.shape.TextBlockRotated;
 import net.sourceforge.plantuml.klimt.shape.UDrawable;
 import net.sourceforge.plantuml.klimt.shape.ULine;
 import net.sourceforge.plantuml.klimt.shape.UPolygon;
@@ -891,10 +892,15 @@ public class SvekEdge extends XAbstractEdge implements XEdge, UDrawable {
 
 		ug = ug.apply(UStroke.simple()).apply(color);
 
-		if (hasNoteLabelText() && this.labelXY != null
-				&& (link.getNote() == null || link.getNote().getStrategy() != NoteLinkStrategy.HALF_NOT_PRINTED))
-			this.labelText.drawU(ug.apply(new UTranslate(x + this.labelXY.getPosition().getX() + labelShield,
-					y + this.labelXY.getPosition().getY() + labelShield)));
+                if (hasNoteLabelText() && this.labelXY != null
+                                && (link.getNote() == null || link.getNote().getStrategy() != NoteLinkStrategy.HALF_NOT_PRINTED)) {
+                        final double angle = Math.toDegrees(Math.atan2(
+                                        dotPath.getEndPoint().getY() - dotPath.getStartPoint().getY(),
+                                        dotPath.getEndPoint().getX() - dotPath.getStartPoint().getX()));
+                        final TextBlock rotated = new TextBlockRotated(this.labelText, angle);
+                        rotated.drawU(ug.apply(new UTranslate(x + this.labelXY.getPosition().getX() + labelShield,
+                                        y + this.labelXY.getPosition().getY() + labelShield)));
+                }
 
 		if (this.startTailText != null && this.startTailLabelXY != null && this.startTailLabelXY.getPosition() != null)
 			this.startTailText.drawU(ug.apply(new UTranslate(x + this.startTailLabelXY.getPosition().getX(),

--- a/src/test/java/net/sourceforge/plantuml/emoji/SvgNanoParserTest.java
+++ b/src/test/java/net/sourceforge/plantuml/emoji/SvgNanoParserTest.java
@@ -1,0 +1,28 @@
+package net.sourceforge.plantuml.emoji;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.klimt.color.HColors;
+import net.sourceforge.plantuml.klimt.drawing.LimitFinder;
+import net.sourceforge.plantuml.klimt.geom.XPoint2D;
+
+public class SvgNanoParserTest {
+
+        @Test
+        public void rectAndLineAnchors() {
+                final String svg = "<svg><rect id=\"r1\" x=\"10\" y=\"20\" width=\"30\" height=\"40\"/>"
+                                + "<line id=\"l1\" x1=\"0\" y1=\"0\" x2=\"60\" y2=\"80\"/></svg>";
+                final SvgNanoParser parser = new SvgNanoParser(svg);
+                parser.drawU(LimitFinder.create(FileFormat.PNG.getDefaultStringBounder(), true), 1, HColors.BLACK, null);
+                final XPoint2D rect = parser.getPoint("r1");
+                assertEquals(25.0, rect.getX(), 0.001);
+                assertEquals(40.0, rect.getY(), 0.001);
+                final XPoint2D line = parser.getPoint("l1");
+                assertEquals(30.0, line.getX(), 0.001);
+                assertEquals(40.0, line.getY(), 0.001);
+        }
+}
+


### PR DESCRIPTION
## Summary
- expand `SvgNanoParser` to parse and render `<rect>` and `<line>` SVG tags
- record element centers by `id` for connecting edges to SVG components
- add regression test for id-based anchor retrieval
- add angle-aware `UText` and rotation helpers
- rotate edge labels so their baseline follows the arrow direction

## Testing
- `./gradlew test --tests net.sourceforge.plantuml.emoji.SvgNanoParserTest`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c694354374832b9a9be30f718b0098